### PR TITLE
Add EditorConfig Settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+# Common settings for all Alan files
+[*.{alan,i,a3sol,a3log}]
+indent_style = space
+indent_size = 2
+charset = latin1
+
+# Additional settings for non-generated Alan files
+[*.{alan,i,a3sol}]
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+
+.editorconfig  text eol=lf
+.gitattributes text
+.gitconfig     text
+.gitignore     text
+.gitmodules    text eol=lf


### PR DESCRIPTION
Add `.editorconfig` file to enforce ISO-8859-1 on Alan sources and
ensure consistent code styling across different editors and IDEs.

Also improves Alan sources visualization on GitHub.

Form more info, visit: https://editorconfig.org/

Add `.gitattribute` with EOL settings for EditorConfig and Git.

Closes alan-if/alan#11.